### PR TITLE
multiple fixes (simutils 1.0.0-beta-005)

### DIFF
--- a/Connector/Connector.csproj
+++ b/Connector/Connector.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-002" />
+    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-005" />
   </ItemGroup>
 
   <!-- Uncomment below to use libraries built locally -->

--- a/manifest.yml
+++ b/manifest.yml
@@ -30,7 +30,6 @@ versions:
         - "Fix the issue where the remote (API) logger didn't respect the minimum log level setting."
         - "Fix the scheduler issue where the simulation was not getting correct UTC run time"
         - "Fix the issue which caused the connector to get stuck if extraction pipeline enabled and API error occurred"
-
   "1.0.0-alpha-117":
     description: Optional data sampling
     changelog:

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,14 @@ extractor:
   image: logo.png
 
 versions:
+  "1.0.0-alpha-118":
+    description: Bug fixes and improvements
+    changelog:
+      fixed:
+        - "Fix the issue where the remote (API) logger didn't respect the minimum log level setting."
+        - "Fix the scheduler issue where the simulation was not getting correct UTC run time"
+        - "Fix the issue which caused the connector to get stuck if extraction pipeline enabled and API error occurred"
+
   "1.0.0-alpha-117":
     description: Optional data sampling
     changelog:


### PR DESCRIPTION
bumping the utils to fix:
- "the issue where the remote (API) logger didn't respect the minimum log level setting."
- "the scheduler issue where the simulation was not getting correct UTC run time"
- "the issue which caused the connector to get stuck if extraction pipeline enabled and API error occurred"