### PR TITLE
update Cognite.Simulator.Utils to 1.0.0-beta-012

### DIFF
--- a/Connector/Connector.csproj
+++ b/Connector/Connector.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-010" />
+    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-012" />
   </ItemGroup>
 
   <!-- Uncomment below to use libraries built locally -->

--- a/Connector/config/config.example.yml
+++ b/Connector/config/config.example.yml
@@ -18,10 +18,7 @@ cognite:
 connector:
   name-prefix: "dwsim-connector@"
   add-machine-name-suffix: true
-
-simulator:
-  name: "DWSIM"
-  data-set-id: ${CDF_CONNECTOR_DATASET}
+  data-set-id: ${COGNITE_DATA_SET_ID}
 
 automation:
   dwsim-installation-path: "C:/Users/user-name/AppData/Local/DWSIM"

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,7 @@ versions:
     changelog:
       added:
         - "Introduced `connector.simulation-run-tolerance` configuration option to prevent simulation runs pile-up. The connector will time out simulation runs that are older than this value (in seconds)."
+      changed:  
         - "**Breaking** Removed redundant `simulator` configuration section from the configuration file, moved the `data-set-id` configuration property under the `connector` section."
   "1.0.0-alpha-125":
     description: Support for bigger model files

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,6 +18,12 @@ extractor:
   image: logo.png
 
 versions:
+  "1.0.0-alpha-126":
+    description: Auto-discarding of old simulation runs & config updates
+    changelog:
+      added:
+        - "Introduced `connector.simulation-run-tolerance` configuration option to prevent simulation runs pile-up. The connector will time out simulation runs that are older than this value (in seconds)."
+        - "**Breaking** Removed redundant `simulator` configuration section from the configuration file, move the `data-set-id` configuration property under the `connector` section."
   "1.0.0-alpha-125":
     description: Support for bigger model files
     changelog:

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,7 @@ versions:
     changelog:
       added:
         - "Introduced `connector.simulation-run-tolerance` configuration option to prevent simulation runs pile-up. The connector will time out simulation runs that are older than this value (in seconds)."
-        - "**Breaking** Removed redundant `simulator` configuration section from the configuration file, move the `data-set-id` configuration property under the `connector` section."
+        - "**Breaking** Removed redundant `simulator` configuration section from the configuration file, moved the `data-set-id` configuration property under the `connector` section."
   "1.0.0-alpha-125":
     description: Support for bigger model files
     changelog:


### PR DESCRIPTION
- Introduced `connector.simulation-run-tolerance` configuration option to prevent simulation runs pile-up. The connector will time out simulation runs that are older than this value (in seconds).
- **Breaking** Removed redundant `simulator` configuration section from the configuration file, move the `data-set-id` configuration property under the `connector` section.