### PR TITLE
chore: enable dotnet analyzers (strict) on build

### DIFF
--- a/Connector/Connector.csproj
+++ b/Connector/Connector.csproj
@@ -9,6 +9,11 @@
     <!-- You may want to uncomment this to debug locally -->
     <!-- <PlatformTarget>x64</PlatformTarget>
     <Configuration>Debug</Configuration> -->
+
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>Default</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Service/Service.csproj
+++ b/Service/Service.csproj
@@ -22,6 +22,11 @@
     <!-- You may want to uncomment this to debug locally -->
     <!-- <PlatformTarget>x64</PlatformTarget>
     <Configuration>Debug</Configuration> -->
+
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisMode>Default</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
we are doing the same for other repos we own.
throws errors on build if there is any warning in the code