### PR TITLE
chore: upgrade simutils to beta-016

### DIFF
--- a/Connector/Connector.csproj
+++ b/Connector/Connector.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-015" />
+    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-016" />
   </ItemGroup>
 
   <!-- Uncomment below to use libraries built locally -->

--- a/Connector/Connector.csproj
+++ b/Connector/Connector.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-012" />
+    <PackageReference Include="Cognite.Simulator.Utils" Version="1.0.0-beta-015" />
   </ItemGroup>
 
   <!-- Uncomment below to use libraries built locally -->

--- a/Connector/Dwsim/DwsimClient.cs
+++ b/Connector/Dwsim/DwsimClient.cs
@@ -86,7 +86,7 @@ namespace Connector.Dwsim
             }
         }
 
-        public void TestConnection()
+        public Task TestConnection(CancellationToken _token)
         {
             _logger.LogInformation("Testing DWSIM connection...");
 
@@ -102,8 +102,8 @@ namespace Connector.Dwsim
                     throw new SimulatorConnectionException($"DWSIM is not available: {e.Message}", e);
                 }
             }
-            _logger.LogInformation(
-                "Connection to DWSIM established and removed successfully");
+            _logger.LogInformation("Connection to DWSIM established and removed successfully");
+            return Task.CompletedTask;
         }
 
         public bool CanOpenModel(string path)
@@ -133,7 +133,7 @@ namespace Connector.Dwsim
             return Server.LoadFlowsheet(path);
         }
 
-        public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(DefaultModelFilestate modelState, SimulatorRoutineRevision routineRev, Dictionary<string, SimulatorValueItem> inputData)
+        public Task<Dictionary<string, SimulatorValueItem>> RunSimulation(DefaultModelFilestate modelState, SimulatorRoutineRevision routineRev, Dictionary<string, SimulatorValueItem> inputData, CancellationToken token)
         {
             _logger.LogDebug($"- Started running {routineRev.ExternalId} in DWSIM");
             lock (_simulatorLock)
@@ -148,7 +148,7 @@ namespace Connector.Dwsim
 
                     var routine = new DwsimRoutine(routineRev, model, Server, inputData, _propMap, _unitConverter, _logger);
 
-                    result = routine.PerformSimulation();
+                    result = routine.PerformSimulation(token);
                     return Task.FromResult(result);
                 }
                 finally
@@ -183,12 +183,12 @@ namespace Connector.Dwsim
             return Task.CompletedTask;
         }
 
-        public string GetSimulatorVersion()
+        public string GetSimulatorVersion(CancellationToken _token)
         {
             return Version;
         }
 
-        public string GetConnectorVersion()
+        public string GetConnectorVersion(CancellationToken _token)
         {
             return Cognite.Extractor.Metrics.Version.GetVersion(
                 Assembly.GetExecutingAssembly(),

--- a/Connector/Dwsim/DwsimRoutine.cs
+++ b/Connector/Dwsim/DwsimRoutine.cs
@@ -61,7 +61,7 @@ internal class DwsimRoutine : RoutineImplementationBase
     }
 
     public override SimulatorValueItem GetOutput(SimulatorRoutineRevisionOutput outputConfig,
-        Dictionary<string, string> arguments)
+        Dictionary<string, string> arguments, CancellationToken _token)
     {
         var (objectName, objectProperty) = GetObjectNameAndProperty(arguments);
 
@@ -91,7 +91,7 @@ internal class DwsimRoutine : RoutineImplementationBase
     }
 
     public override void SetInput(SimulatorRoutineRevisionInput inputConfig, SimulatorValueItem input,
-        Dictionary<string, string> arguments)
+        Dictionary<string, string> arguments, CancellationToken _token)
     {
         var (objectName, objectProperty) = GetObjectNameAndProperty(arguments);
         var simulatorObjectReference = new Dictionary<string, string>()
@@ -104,7 +104,7 @@ internal class DwsimRoutine : RoutineImplementationBase
         SetProperty(_model, objectName, objectProperty, input, _propMap, _units, _logger);
     }
 
-    public override void RunCommand(Dictionary<string, string> arguments)
+    public override void RunCommand(Dictionary<string, string> arguments, CancellationToken _token)
     {
         if (!arguments.TryGetValue("command", out string? command))
         {


### PR DESCRIPTION
- a bunch of methods now accept cancellation tokes. for DWSIM we don't need those in general, so this doesn't change the implementation (only signature)
- TestConnection returns a Task as it might be async for some of the simulators (not for DWSIM)
