### PR TITLE
chore: fix coverage upload to codecov

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,10 +31,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal /p:Exclude="[*.Test]*" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:CoverletOutput=TestResults/
+      run: dotnet test --no-build --verbosity normal --collect:"XPlat Code Coverage;Format=opencover"
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
       with:
-        path: ./TestResults/coverage.opencover.xml
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,4 +36,5 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
       with:
+        path: ./TestResults/coverage.opencover.xml
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ configurations/*
 Service/configurations/*
 Service/files/*
 .idea/*
+/Connector.Tests/TestResults

--- a/Connector.Tests/Connector.Tests.csproj
+++ b/Connector.Tests/Connector.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
the coverage is not being generated/uploaded to codecov, seems like due to the misconfiguration for coverlet. (see the comment below, it is fixed)

I am using a modern style here, without msbuild: https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-code-coverage?tabs=linux