### PR TITLE
chore(ci): run tests on master

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,6 +3,8 @@ name: .NET build and test
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 jobs:
   common:

--- a/Connector/ConnectorRuntime.cs
+++ b/Connector/ConnectorRuntime.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Connector;
+
 public static class ConnectorRuntime
 {
 


### PR DESCRIPTION
We currently don't run tests on master, this is a problem, because we don't see the things like test coverage, etc.

Enabling test suite to be run on master as well

Added a new line, since the formatter is now failing on .NET 10