### PR TITLE
Add COM property extraction for DWSIM model nodes

### DIFF
--- a/Connector.Tests/Dwsim/DwsimModelParserComTests.cs
+++ b/Connector.Tests/Dwsim/DwsimModelParserComTests.cs
@@ -48,14 +48,14 @@ public class DwsimModelParserComTests
     public void ExtractNodePropertiesFromCom_WithValidProperties_ShouldReturnProperties()
     {
         // Arrange
-        var mockCom = MockDwsimProxy.Create(
+        dynamic mockCom = MockDwsimProxy.Create(
             writeProps: ["Temperature", "Pressure"],
             readProps: ["Temperature", "Pressure", "Density"],
             values: new() { { "Temperature", 25.5 }, { "Pressure", 101325.0 }, { "Density", 1000.0 } },
             units: new() { { "Temperature", "C" }, { "Pressure", "Pa" }, { "Density", "kg/m3" } });
 
         // Act
-        List<SimulatorModelRevisionDataProperty> properties = _parser.ExtractNodePropertiesFromComPublic(mockCom, "MaterialStream", "S-01");
+        List<SimulatorModelRevisionDataProperty> properties = _parser.DoExtractNodePropertiesFromCom(mockCom, "MaterialStream", "S-01");
 
         // Assert
         Assert.Equal(3, properties.Count);
@@ -71,14 +71,14 @@ public class DwsimModelParserComTests
     public void CreateModelProperty_WithDoubleValues_ShouldHandleValidAndInvalid(double value, bool shouldBeNull)
     {
         // Arrange
-        var mockCom = MockDwsimProxy.Create(
+        dynamic mockCom = MockDwsimProxy.Create(
             writeProps: ["TestProp"],
             readProps: ["TestProp"],
             values: new() { { "TestProp", value } },
             units: new() { { "TestProp", "kg/h" } });
 
         // Act
-        var property = _parser.CreateModelPropertyPublic("TestProp", mockCom, "Stream", "S-01", new[] { "TestProp" });
+        dynamic property = _parser.DoCreateModelProperty("TestProp", mockCom, "Stream", "S-01", new[] { "TestProp" });
 
         // Assert
         if (shouldBeNull)
@@ -97,14 +97,14 @@ public class DwsimModelParserComTests
     public void CreateModelProperty_WithBoolValue_ShouldConvertToDouble()
     {
         // Arrange
-        var mockCom = MockDwsimProxy.Create(
+        dynamic mockCom = MockDwsimProxy.Create(
             writeProps: ["Active"],
             readProps: ["Active"],
             values: new() { { "Active", true } },
             units: new() { { "Active", "" } });
 
         // Act
-        var property = _parser.CreateModelPropertyPublic("Active", mockCom, "Valve", "V-01", new[] { "Active" });
+        dynamic property = _parser.DoCreateModelProperty("Active", mockCom, "Valve", "V-01", new[] { "Active" });
 
         // Assert
         Assert.NotNull(property);
@@ -117,21 +117,21 @@ public class DwsimModelParserComTests
     public void CreateModelProperty_WithPropPrefix_ShouldTranslateName()
     {
         // Arrange
-        var mockCom = MockDwsimProxy.Create(
+        dynamic mockCom = MockDwsimProxy.Create(
             writeProps: ["PROP_MS_0", "PROP_MS_105/Oxygen"],
             readProps: ["PROP_MS_0", "PROP_MS_105/Oxygen"],
             values: new() { { "PROP_MS_0", 298.15 }, { "PROP_MS_105/Oxygen", 0.21 } },
             units: new() { { "PROP_MS_0", "K" }, { "PROP_MS_105/Oxygen", "kg/s" } });
 
         // Act - Test simple PROP translation
-        var property = _parser.CreateModelPropertyPublic("PROP_MS_0", mockCom, "Stream", "S-01", new[] { "PROP_MS_0", "PROP_MS_105/Oxygen" });
+        dynamic property = _parser.DoCreateModelProperty("PROP_MS_0", mockCom, "Stream", "S-01", new[] { "PROP_MS_0", "PROP_MS_105/Oxygen" });
 
         // Assert
         Assert.NotNull(property);
         Assert.Equal("Temperature", property.Name);
 
         // Act - Test PROP with suffix translation (mixture property)
-        var mixtureProperty = _parser.CreateModelPropertyPublic("PROP_MS_105/Oxygen", mockCom, "Stream", "S-01", new[] { "PROP_MS_0", "PROP_MS_105/Oxygen" });
+        dynamic mixtureProperty = _parser.DoCreateModelProperty("PROP_MS_105/Oxygen", mockCom, "Stream", "S-01", new[] { "PROP_MS_0", "PROP_MS_105/Oxygen" });
 
         // Assert
         Assert.NotNull(mixtureProperty);
@@ -144,15 +144,15 @@ public class DwsimModelParserComTests
     public void CreateModelProperty_WithDoubleArray_ShouldCreateArrayProperty()
     {
         // Arrange
-        var array = new double[] { 0.25, 0.50, 0.25 };
-        var mockCom = MockDwsimProxy.Create(
+        double[] array = [0.25, 0.50, 0.25];
+        dynamic mockCom = MockDwsimProxy.Create(
             writeProps: ["Composition"],
             readProps: ["Composition"],
             values: new() { { "Composition", array } },
             units: new() { { "Composition", "" } });
 
         // Act
-        var property = _parser.CreateModelPropertyPublic("Composition", mockCom, "Stream", "S-01", new[] { "Composition" });
+        dynamic property = _parser.DoCreateModelProperty("Composition", mockCom, "Stream", "S-01", new[] { "Composition" });
 
         // Assert
         Assert.NotNull(property);
@@ -163,14 +163,14 @@ public class DwsimModelParserComTests
     public void CreateModelProperty_WithReadOnlyProperty_ShouldSetReadOnlyTrue()
     {
         // Arrange
-        var mockCom = MockDwsimProxy.Create(
+        dynamic mockCom = MockDwsimProxy.Create(
             writeProps: ["Temperature"],
             readProps: ["Temperature", "Density"],
             values: new() { { "Density", 1000.0 } },
             units: new() { { "Density", "kg/m3" } });
 
         // Act
-        var property = _parser.CreateModelPropertyPublic("Density", mockCom, "Stream", "S-01", new[] { "Temperature" });
+        dynamic property = _parser.DoCreateModelProperty("Density", mockCom, "Stream", "S-01", new[] { "Temperature" });
 
         // Assert
         Assert.NotNull(property);
@@ -184,11 +184,11 @@ public class DwsimModelParserComTests
         {
         }
 
-        public List<SimulatorModelRevisionDataProperty> ExtractNodePropertiesFromComPublic(
+        public List<SimulatorModelRevisionDataProperty> DoExtractNodePropertiesFromCom(
             dynamic obj, string objectType, string nodeName)
             => ExtractNodePropertiesFromCom(obj, objectType, nodeName);
 
-        public SimulatorModelRevisionDataProperty? CreateModelPropertyPublic(
+        public SimulatorModelRevisionDataProperty? DoCreateModelProperty(
             string propertyKey, dynamic obj, string objectType, string objectName, dynamic writeProperties)
             => CreateModelProperty(propertyKey, obj, objectType, objectName, writeProperties);
     }

--- a/Connector.Tests/Dwsim/DwsimModelParserComTests.cs
+++ b/Connector.Tests/Dwsim/DwsimModelParserComTests.cs
@@ -1,0 +1,282 @@
+/**
+ * Copyright 2025 Cognite AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Reflection;
+using CogniteSdk.Alpha;
+using Connector.Dwsim;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Connector.Tests.Dwsim;
+
+/// <summary>
+/// Tests for COM property extraction methods in DwsimModelParser.
+/// Uses DispatchProxy to create dynamic mock COM objects for testing.
+/// </summary>
+public class DwsimModelParserComTests
+{
+    private readonly Mock<ILogger<DwsimClient>> _mockLogger;
+    private readonly Dictionary<string, string> _propMap;
+    private readonly TestableComParser _parser;
+
+    public DwsimModelParserComTests()
+    {
+        _mockLogger = new Mock<ILogger<DwsimClient>>();
+        _propMap = new Dictionary<string, string>
+        {
+            { "PROP_MS_0", "Temperature" },
+            { "PROP_MS_2", "Mass Flow" },
+            { "PROP_MS_105", "Mass Flow (Mixture)" }
+        };
+        _parser = new TestableComParser(_mockLogger.Object, _propMap);
+    }
+
+    [Fact]
+    public void ExtractNodePropertiesFromCom_WithValidProperties_ShouldReturnProperties()
+    {
+        // Arrange
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["Temperature", "Pressure"],
+            readProps: ["Temperature", "Pressure", "Density"],
+            values: new() { { "Temperature", 25.5 }, { "Pressure", 101325.0 }, { "Density", 1000.0 } },
+            units: new() { { "Temperature", "C" }, { "Pressure", "Pa" }, { "Density", "kg/m3" } });
+
+        // Act
+        List<SimulatorModelRevisionDataProperty> properties = _parser.ExtractNodePropertiesFromComPublic(mockCom, "MaterialStream", "S-01");
+
+        // Assert
+        Assert.Equal(3, properties.Count);
+        Assert.Contains(properties, p => p.Name == "Temperature" && p.ReadOnly == false);
+        Assert.Contains(properties, p => p.Name == "Density" && p.ReadOnly == true);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void CreateModelProperty_WithInvalidDouble_ShouldReturnNull(double invalidValue)
+    {
+        // Arrange
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["BadProp"],
+            readProps: ["BadProp"],
+            values: new() { { "BadProp", invalidValue } },
+            units: new() { { "BadProp", "K" } });
+
+        // Act
+        var property = _parser.CreateModelPropertyPublic("BadProp", mockCom, "Heater", "H-01", new[] { "BadProp" });
+
+        // Assert
+        Assert.Null(property);
+    }
+
+    [Fact]
+    public void CreateModelProperty_WithDoubleValue_ShouldCreateCorrectProperty()
+    {
+        // Arrange
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["Flow"],
+            readProps: ["Flow"],
+            values: new() { { "Flow", 100.5 } },
+            units: new() { { "Flow", "kg/h" } });
+
+        // Act
+        var property = _parser.CreateModelPropertyPublic("Flow", mockCom, "Stream", "S-01", new[] { "Flow" });
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal("Flow", property.Name);
+        Assert.Equal(SimulatorValueType.DOUBLE, property.ValueType);
+        Assert.False(property.ReadOnly);
+        Assert.Equal("kg/h", property.Unit?.Name);
+    }
+
+    [Fact]
+    public void CreateModelProperty_WithBoolValue_ShouldConvertToDouble()
+    {
+        // Arrange
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["Active"],
+            readProps: ["Active"],
+            values: new() { { "Active", true } },
+            units: new() { { "Active", "" } });
+
+        // Act
+        var property = _parser.CreateModelPropertyPublic("Active", mockCom, "Valve", "V-01", new[] { "Active" });
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal(SimulatorValueType.DOUBLE, property.ValueType);
+        var doubleValue = (SimulatorValue.Double)property.Value!;
+        Assert.Equal(1.0, doubleValue.Value);
+    }
+
+    [Fact]
+    public void CreateModelProperty_WithPropPrefix_ShouldTranslateName()
+    {
+        // Arrange
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["PROP_MS_0", "PROP_MS_105/Oxygen"],
+            readProps: ["PROP_MS_0", "PROP_MS_105/Oxygen"],
+            values: new() { { "PROP_MS_0", 298.15 }, { "PROP_MS_105/Oxygen", 0.21 } },
+            units: new() { { "PROP_MS_0", "K" }, { "PROP_MS_105/Oxygen", "kg/s" } });
+
+        // Act - Test simple PROP translation
+        var property = _parser.CreateModelPropertyPublic("PROP_MS_0", mockCom, "Stream", "S-01", new[] { "PROP_MS_0", "PROP_MS_105/Oxygen" });
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal("Temperature", property.Name);
+
+        // Act - Test PROP with suffix translation (mixture property)
+        var mixtureProperty = _parser.CreateModelPropertyPublic("PROP_MS_105/Oxygen", mockCom, "Stream", "S-01", new[] { "PROP_MS_0", "PROP_MS_105/Oxygen" });
+
+        // Assert
+        Assert.NotNull(mixtureProperty);
+        Assert.Equal("Mass Flow (Mixture)/Oxygen", mixtureProperty.Name);
+        Assert.Equal("kg/s", mixtureProperty.Unit?.Name);
+        Assert.Equal(0.21, ((SimulatorValue.Double)mixtureProperty.Value!).Value);
+    }
+
+    [Fact]
+    public void CreateModelProperty_WithDoubleArray_ShouldCreateArrayProperty()
+    {
+        // Arrange
+        var array = new double[] { 0.25, 0.50, 0.25 };
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["Composition"],
+            readProps: ["Composition"],
+            values: new() { { "Composition", array } },
+            units: new() { { "Composition", "" } });
+
+        // Act
+        var property = _parser.CreateModelPropertyPublic("Composition", mockCom, "Stream", "S-01", new[] { "Composition" });
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.Equal(SimulatorValueType.DOUBLE_ARRAY, property.ValueType);
+    }
+
+    [Fact]
+    public void CreateModelProperty_WithReadOnlyProperty_ShouldSetReadOnlyTrue()
+    {
+        // Arrange
+        var mockCom = MockDwsimProxy.Create(
+            writeProps: ["Temperature"],
+            readProps: ["Temperature", "Density"],
+            values: new() { { "Density", 1000.0 } },
+            units: new() { { "Density", "kg/m3" } });
+
+        // Act
+        var property = _parser.CreateModelPropertyPublic("Density", mockCom, "Stream", "S-01", new[] { "Temperature" });
+
+        // Assert
+        Assert.NotNull(property);
+        Assert.True(property.ReadOnly);
+    }
+
+    [Fact]
+    public void DwsimModelParsingConfig_HasCorrectDefaults()
+    {
+        var config = new DwsimModelParsingConfig();
+        Assert.Equal(100, config.MaxPropertiesPerNode);
+    }
+
+    private class TestableComParser : DwsimModelParser
+    {
+        public TestableComParser(ILogger<DwsimClient> logger, Dictionary<string, string> propMap)
+            : base(logger, propMap, "dummy-path", new MockUnitSystem())
+        {
+        }
+
+        public List<SimulatorModelRevisionDataProperty> ExtractNodePropertiesFromComPublic(
+            dynamic obj, string objectType, string nodeName)
+            => ExtractNodePropertiesFromCom(obj, objectType, nodeName);
+
+        public SimulatorModelRevisionDataProperty? CreateModelPropertyPublic(
+            string propertyKey, dynamic obj, string objectType, string objectName, dynamic writeProperties)
+            => CreateModelProperty(propertyKey, obj, objectType, objectName, writeProperties);
+    }
+
+    public class MockUnitSystem
+    {
+        public string? GetUnitType(string unit) => unit switch
+        {
+            "C" or "K" => "temperature",
+            "Pa" or "bar" => "pressure",
+            "kg/m3" => "density",
+            "kg/h" or "kg/s" => "massflow",
+            _ => "none"
+        };
+    }
+}
+
+/// <summary>
+/// DispatchProxy-based mock for DWSIM COM objects
+/// </summary>
+public class MockDwsimProxy : DispatchProxy
+{
+    private string[] _writeProps = Array.Empty<string>();
+    private string[] _readProps = Array.Empty<string>();
+    private Dictionary<string, object> _values = new();
+    private Dictionary<string, string> _units = new();
+
+    public static dynamic Create(
+        string[] writeProps,
+        string[] readProps,
+        Dictionary<string, object> values,
+        Dictionary<string, string> units)
+    {
+        object proxy = Create<IDwsimComObject, MockDwsimProxy>();
+        ((MockDwsimProxy)proxy).Initialize(writeProps, readProps, values, units);
+        return proxy;
+    }
+
+    private void Initialize(
+        string[] writeProps,
+        string[] readProps,
+        Dictionary<string, object> values,
+        Dictionary<string, string> units)
+    {
+        _writeProps = writeProps;
+        _readProps = readProps;
+        _values = values;
+        _units = units;
+    }
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod == null) return null;
+
+        return targetMethod.Name switch
+        {
+            nameof(IDwsimComObject.GetProperties) => args?[0] is int type && type == 1 ? _writeProps : _readProps,
+            nameof(IDwsimComObject.GetPropertyValue) => args?[0] is string key ? _values.GetValueOrDefault(key) : null,
+            nameof(IDwsimComObject.GetPropertyUnit) => args?[0] is string key ? _units.GetValueOrDefault(key, "") : "",
+            _ => null
+        };
+    }
+}
+
+/// <summary>
+/// Interface representing DWSIM COM object contract
+/// </summary>
+public interface IDwsimComObject
+{
+    string[] GetProperties(int propertyType);
+    object? GetPropertyValue(string key);
+    string GetPropertyUnit(string key);
+}

--- a/Connector.Tests/Dwsim/DwsimModelParserComTests.cs
+++ b/Connector.Tests/Dwsim/DwsimModelParserComTests.cs
@@ -64,44 +64,33 @@ public class DwsimModelParserComTests
     }
 
     [Theory]
-    [InlineData(double.NaN)]
-    [InlineData(double.PositiveInfinity)]
-    [InlineData(double.NegativeInfinity)]
-    public void CreateModelProperty_WithInvalidDouble_ShouldReturnNull(double invalidValue)
+    [InlineData(double.NaN, true)]
+    [InlineData(double.PositiveInfinity, true)]
+    [InlineData(double.NegativeInfinity, true)]
+    [InlineData(100.5, false)]
+    public void CreateModelProperty_WithDoubleValues_ShouldHandleValidAndInvalid(double value, bool shouldBeNull)
     {
         // Arrange
         var mockCom = MockDwsimProxy.Create(
-            writeProps: ["BadProp"],
-            readProps: ["BadProp"],
-            values: new() { { "BadProp", invalidValue } },
-            units: new() { { "BadProp", "K" } });
+            writeProps: ["TestProp"],
+            readProps: ["TestProp"],
+            values: new() { { "TestProp", value } },
+            units: new() { { "TestProp", "kg/h" } });
 
         // Act
-        var property = _parser.CreateModelPropertyPublic("BadProp", mockCom, "Heater", "H-01", new[] { "BadProp" });
+        var property = _parser.CreateModelPropertyPublic("TestProp", mockCom, "Stream", "S-01", new[] { "TestProp" });
 
         // Assert
-        Assert.Null(property);
-    }
-
-    [Fact]
-    public void CreateModelProperty_WithDoubleValue_ShouldCreateCorrectProperty()
-    {
-        // Arrange
-        var mockCom = MockDwsimProxy.Create(
-            writeProps: ["Flow"],
-            readProps: ["Flow"],
-            values: new() { { "Flow", 100.5 } },
-            units: new() { { "Flow", "kg/h" } });
-
-        // Act
-        var property = _parser.CreateModelPropertyPublic("Flow", mockCom, "Stream", "S-01", new[] { "Flow" });
-
-        // Assert
-        Assert.NotNull(property);
-        Assert.Equal("Flow", property.Name);
-        Assert.Equal(SimulatorValueType.DOUBLE, property.ValueType);
-        Assert.False(property.ReadOnly);
-        Assert.Equal("kg/h", property.Unit?.Name);
+        if (shouldBeNull)
+        {
+            Assert.Null(property);
+        }
+        else
+        {
+            Assert.NotNull(property);
+            Assert.Equal(SimulatorValueType.DOUBLE, property.ValueType);
+            Assert.Equal("kg/h", property.Unit?.Name);
+        }
     }
 
     [Fact]
@@ -186,13 +175,6 @@ public class DwsimModelParserComTests
         // Assert
         Assert.NotNull(property);
         Assert.True(property.ReadOnly);
-    }
-
-    [Fact]
-    public void DwsimModelParsingConfig_HasCorrectDefaults()
-    {
-        var config = new DwsimModelParsingConfig();
-        Assert.Equal(100, config.MaxPropertiesPerNode);
     }
 
     private class TestableComParser : DwsimModelParser

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -697,7 +697,15 @@ public class DwsimModelParser
                 {
                     double[] doubles = new double[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
-                        doubles[i] = Convert.ToDouble(arr.GetValue(i));
+                    {
+                        double val = Convert.ToDouble(arr.GetValue(i));
+                        if (double.IsNaN(val) || double.IsInfinity(val))
+                        {
+                            _logger.LogDebug("Array for property {PropKey} contains invalid double value at index {Index}", propertyKey, i);
+                            return null;
+                        }
+                        doubles[i] = val;
+                    }
                     return SimulatorValue.Create(doubles);
                 }
                 else

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Collections;
 using System.Globalization;
 using System.IO.Compression;
 using System.Reflection;
@@ -508,6 +509,230 @@ public class DwsimModelParser
             Components = components,
             PropertyPackages = propertyPackages
         };
+    }
+
+    /// <summary>
+    /// Extracts properties from a DWSIM COM object
+    /// </summary>
+    /// <param name="obj">The COM object to extract properties from</param>
+    /// <param name="objectType">Type of the object</param>
+    /// <param name="nodeName">Name of the node</param>
+    /// <returns>List of extracted properties</returns>
+    internal List<SimulatorModelRevisionDataProperty> ExtractNodePropertiesFromCom(
+        dynamic obj, string objectType, string nodeName)
+    {
+        var properties = new List<SimulatorModelRevisionDataProperty>();
+        int extractedCount = 0;
+
+        try
+        {
+            // Get write and read properties using GetProperties method exposed by the BaseClass interface
+            // https://dwsim.org/api_help/html/T_DWSIM_SharedClasses_UnitOperations_BaseClass.htm
+            // GetProperties(1) returns only properties that can be written to
+            // GetProperties(3) returns all properties that can be read from
+            dynamic? writeProperties = obj.GetProperties(1);
+            dynamic? readProperties = obj.GetProperties(3);
+
+            // Combine all properties, avoiding duplicates
+            var allProperties = new HashSet<string>(writeProperties);
+            foreach (string prop in readProperties)
+            {
+                allProperties.Add(prop);
+            }
+
+            foreach (string property in allProperties)
+            {
+                if (extractedCount >= _modelParsingConfig.MaxPropertiesPerNode)
+                {
+                    _logger.LogDebug("Reached max properties limit ({MaxProperties}) for node {NodeName}",
+                        _modelParsingConfig.MaxPropertiesPerNode, nodeName);
+                    break;
+                }
+
+                try
+                {
+                    SimulatorModelRevisionDataProperty? modelProperty =
+                        CreateModelProperty(property, obj, objectType, nodeName, writeProperties);
+                    if (modelProperty != null)
+                    {
+                        properties.Add(modelProperty);
+                        extractedCount++;
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.LogDebug("Skipped property {PropName} for node {NodeName}: {EMessage}",
+                        property, nodeName, e.Message);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning("Error extracting properties from COM object for node {NodeName}: {EMessage}",
+                nodeName, e.Message);
+        }
+
+        return properties;
+    }
+
+    /// <summary>
+    /// Creates a model property from a DWSIM COM object property
+    /// </summary>
+    /// <param name="propertyKey">The property key</param>
+    /// <param name="obj">The COM object</param>
+    /// <param name="objectType">Type of the object</param>
+    /// <param name="objectName">Name of the object</param>
+    /// <param name="writeProperties">List of writable properties</param>
+    /// <returns>Created property or null if property cannot be processed</returns>
+    internal SimulatorModelRevisionDataProperty? CreateModelProperty(
+        string propertyKey, dynamic obj, string objectType,
+        string objectName, dynamic writeProperties)
+    {
+        try
+        {
+            // Get property value from COM object
+            // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_UnitOperations_BaseClass_GetPropertyValue.htm
+            dynamic value = obj.GetPropertyValue(propertyKey);
+            if (value == null)
+                return null;
+
+            // Handle PROP_ prefix translation using prop map
+            // Some properties have internal keys that are not human readable names
+            // Example: "PROP_MS_0" -> "Temperature"
+            //          "PROP_MS_105/Oxygen" -> "Mass Flow (Mixture)/Oxygen"
+            // https://dwsim.org/wiki/index.php?title=Object_Property_Codes
+            string propertyName = propertyKey;
+            if (propertyKey.StartsWith("PROP"))
+            {
+                // Mixture properties contain a suffix after a slash (e.g., PROP_MS_105/Oxygen)
+                // We translate only the PROP_ part and preserve the suffix
+                string[] parts = propertyKey.Split('/', 2);
+                string propCode = parts[0];  // e.g., "PROP_MS_105"
+                string? suffix = parts.Length > 1 ? parts[1] : null;  // e.g., "Oxygen"
+
+                if (_propMap.TryGetValue(propCode, out string? humanReadableName))
+                {
+                    propertyName = suffix != null
+                        ? $"{humanReadableName}/{suffix}"
+                        : humanReadableName;
+                }
+            }
+
+            // Get unit information from COM object
+            // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_UnitOperations_BaseClass_GetPropertyUnit.htm
+            string unit = obj.GetPropertyUnit(propertyKey) ?? "";
+            SimulatorValueUnitReference? unitReference = null;
+            if (!string.IsNullOrEmpty(unit))
+            {
+                // Map unit to unit type using DWSIM unit system
+                // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_SystemsOfUnits_Units_GetUnitType.htm
+                string unitType = _unitSystem?.GetUnitType(unit)?.ToString() ?? "";
+                if (unitType != "none" && !string.IsNullOrEmpty(unitType))
+                {
+                    unitReference = new SimulatorValueUnitReference
+                    {
+                        Name = unit,
+                        Quantity = unitType
+                    };
+                }
+            }
+
+            // Determine value type and create simulator value
+            SimulatorValueType valueType;
+            SimulatorValue? simulatorValue;
+
+            switch (value)
+            {
+                case double doubleValue when double.IsNaN(doubleValue) || double.IsInfinity(doubleValue):
+                    return null;
+                case double doubleValue:
+                    valueType = SimulatorValueType.DOUBLE;
+                    simulatorValue = SimulatorValue.Create(doubleValue);
+                    break;
+
+                case float floatValue when float.IsNaN(floatValue) || float.IsInfinity(floatValue):
+                    return null;
+                case float floatValue:
+                    valueType = SimulatorValueType.DOUBLE;
+                    simulatorValue = SimulatorValue.Create((double)floatValue);
+                    break;
+
+                case int intValue:
+                    valueType = SimulatorValueType.DOUBLE;
+                    simulatorValue = SimulatorValue.Create(intValue);
+                    break;
+
+                // TODO: Update logic if we extend the API to support boolean type natively
+                case bool boolValue:
+                    valueType = SimulatorValueType.DOUBLE;
+                    simulatorValue = SimulatorValue.Create(boolValue ? 1.0 : 0.0);
+                    break;
+
+                case string stringValue:
+                    valueType = SimulatorValueType.STRING;
+                    simulatorValue = SimulatorValue.Create(stringValue);
+                    break;
+
+                case Array { Length: 0 }:
+                    return null;
+
+                case Array arrayValue:
+                {
+                    // All elements in arrays are of the same type in DWSIM
+                    object? firstElement = arrayValue.GetValue(0);
+                    if (firstElement is double or float or int)
+                    {
+                        valueType = SimulatorValueType.DOUBLE_ARRAY;
+                        double[] doubleArray = new double[arrayValue.Length];
+                        for (int i = 0; i < arrayValue.Length; i++)
+                        {
+                            doubleArray[i] = Convert.ToDouble(arrayValue.GetValue(i));
+                        }
+                        simulatorValue = SimulatorValue.Create(doubleArray);
+                    }
+                    else
+                    {
+                        valueType = SimulatorValueType.STRING_ARRAY;
+                        string[] stringArray = new string[arrayValue.Length];
+                        for (int i = 0; i < arrayValue.Length; i++)
+                        {
+                            stringArray[i] = arrayValue.GetValue(i)?.ToString() ?? "";
+                        }
+                        simulatorValue = SimulatorValue.Create(stringArray);
+                    }
+                    break;
+                }
+
+                default:
+                    string valueTypeName = value.GetType().Name;
+                    _logger.LogDebug("Unsupported value type {ValueType} for property {PropKey}",
+                        valueTypeName, propertyKey);
+                    return null;
+            }
+
+            // Check if property is read-only by checking if it's in the write properties list
+            bool isReadOnly = !((IList)writeProperties).Contains(propertyKey);
+
+            return new SimulatorModelRevisionDataProperty
+            {
+                Name = propertyName, // Human-readable name
+                ValueType = valueType,
+                Value = simulatorValue,
+                Unit = unitReference,
+                ReadOnly = isReadOnly,
+                ReferenceObject = new Dictionary<string, string>
+                {
+                    { "objectType", objectType },
+                    { "objectName", objectName },
+                    { "objectProperty", propertyKey } // access is done using the internal property key
+                }
+            };
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug("Error creating model property for {PropKey}: {EMessage}", propertyKey, e.Message);
+            return null;
+        }
     }
 }
 

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -534,11 +534,12 @@ public class DwsimModelParser
             dynamic? readProperties = obj.GetProperties(3);
 
             // Combine all properties, avoiding duplicates
-            var allProperties = new HashSet<string>(writeProperties);
-            foreach (string prop in readProperties)
-            {
-                allProperties.Add(prop);
-            }
+            var allProperties = new HashSet<string>();
+            if (writeProperties != null)
+                foreach (string prop in writeProperties) allProperties.Add(prop);
+
+            if (readProperties != null)
+                foreach (string prop in readProperties) allProperties.Add(prop);
 
             foreach (string property in allProperties)
             {
@@ -600,7 +601,7 @@ public class DwsimModelParser
             if (simulatorValue == null)
                 return null;
 
-            bool isReadOnly = !((IList)writeProperties).Contains(propertyKey);
+            bool isReadOnly = writeProperties is null || !((IList)writeProperties).Contains(propertyKey);
 
             return new SimulatorModelRevisionDataProperty
             {

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -596,135 +596,24 @@ public class DwsimModelParser
             if (value == null)
                 return null;
 
-            // Handle PROP_ prefix translation using prop map
-            // Some properties have internal keys that are not human readable names
-            // Example: "PROP_MS_0" -> "Temperature"
-            //          "PROP_MS_105/Oxygen" -> "Mass Flow (Mixture)/Oxygen"
-            // https://dwsim.org/wiki/index.php?title=Object_Property_Codes
-            string propertyName = propertyKey;
-            if (propertyKey.StartsWith("PROP"))
-            {
-                // Mixture properties contain a suffix after a slash (e.g., PROP_MS_105/Oxygen)
-                // We translate only the PROP_ part and preserve the suffix
-                string[] parts = propertyKey.Split('/', 2);
-                string propCode = parts[0];  // e.g., "PROP_MS_105"
-                string? suffix = parts.Length > 1 ? parts[1] : null;  // e.g., "Oxygen"
+            SimulatorValue? simulatorValue = ConvertToSimulatorValue(value, propertyKey);
+            if (simulatorValue == null)
+                return null;
 
-                if (_propMap.TryGetValue(propCode, out string? humanReadableName))
-                {
-                    propertyName = suffix != null
-                        ? $"{humanReadableName}/{suffix}"
-                        : humanReadableName;
-                }
-            }
-
-            // Get unit information from COM object
-            // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_UnitOperations_BaseClass_GetPropertyUnit.htm
-            string unit = obj.GetPropertyUnit(propertyKey) ?? "";
-            SimulatorValueUnitReference? unitReference = null;
-            if (!string.IsNullOrEmpty(unit))
-            {
-                // Map unit to unit type using DWSIM unit system
-                // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_SystemsOfUnits_Units_GetUnitType.htm
-                string unitType = _unitSystem?.GetUnitType(unit)?.ToString() ?? "";
-                if (unitType != "none" && !string.IsNullOrEmpty(unitType))
-                {
-                    unitReference = new SimulatorValueUnitReference
-                    {
-                        Name = unit,
-                        Quantity = unitType
-                    };
-                }
-            }
-
-            // Determine value type and create simulator value
-            SimulatorValueType valueType;
-            SimulatorValue? simulatorValue;
-
-            switch (value)
-            {
-                case double doubleValue when double.IsNaN(doubleValue) || double.IsInfinity(doubleValue):
-                    return null;
-                case double doubleValue:
-                    valueType = SimulatorValueType.DOUBLE;
-                    simulatorValue = SimulatorValue.Create(doubleValue);
-                    break;
-
-                case float floatValue when float.IsNaN(floatValue) || float.IsInfinity(floatValue):
-                    return null;
-                case float floatValue:
-                    valueType = SimulatorValueType.DOUBLE;
-                    simulatorValue = SimulatorValue.Create((double)floatValue);
-                    break;
-
-                case int intValue:
-                    valueType = SimulatorValueType.DOUBLE;
-                    simulatorValue = SimulatorValue.Create(intValue);
-                    break;
-
-                // TODO: Update logic if we extend the API to support boolean type natively
-                case bool boolValue:
-                    valueType = SimulatorValueType.DOUBLE;
-                    simulatorValue = SimulatorValue.Create(boolValue ? 1.0 : 0.0);
-                    break;
-
-                case string stringValue:
-                    valueType = SimulatorValueType.STRING;
-                    simulatorValue = SimulatorValue.Create(stringValue);
-                    break;
-
-                case Array { Length: 0 }:
-                    return null;
-
-                case Array arrayValue:
-                {
-                    // All elements in arrays are of the same type in DWSIM
-                    object? firstElement = arrayValue.GetValue(0);
-                    if (firstElement is double or float or int)
-                    {
-                        valueType = SimulatorValueType.DOUBLE_ARRAY;
-                        double[] doubleArray = new double[arrayValue.Length];
-                        for (int i = 0; i < arrayValue.Length; i++)
-                        {
-                            doubleArray[i] = Convert.ToDouble(arrayValue.GetValue(i));
-                        }
-                        simulatorValue = SimulatorValue.Create(doubleArray);
-                    }
-                    else
-                    {
-                        valueType = SimulatorValueType.STRING_ARRAY;
-                        string[] stringArray = new string[arrayValue.Length];
-                        for (int i = 0; i < arrayValue.Length; i++)
-                        {
-                            stringArray[i] = arrayValue.GetValue(i)?.ToString() ?? "";
-                        }
-                        simulatorValue = SimulatorValue.Create(stringArray);
-                    }
-                    break;
-                }
-
-                default:
-                    string valueTypeName = value.GetType().Name;
-                    _logger.LogDebug("Unsupported value type {ValueType} for property {PropKey}",
-                        valueTypeName, propertyKey);
-                    return null;
-            }
-
-            // Check if property is read-only by checking if it's in the write properties list
             bool isReadOnly = !((IList)writeProperties).Contains(propertyKey);
 
             return new SimulatorModelRevisionDataProperty
             {
-                Name = propertyName, // Human-readable name
-                ValueType = valueType,
+                Name = GetHumanReadablePropertyName(propertyKey),
+                ValueType = simulatorValue.Type,
                 Value = simulatorValue,
-                Unit = unitReference,
+                Unit = GetUnitReference(obj, propertyKey),
                 ReadOnly = isReadOnly,
                 ReferenceObject = new Dictionary<string, string>
                 {
                     { "objectType", objectType },
                     { "objectName", objectName },
-                    { "objectProperty", propertyKey } // access is done using the internal property key
+                    { "objectProperty", propertyKey }
                 }
             };
         }
@@ -732,6 +621,98 @@ public class DwsimModelParser
         {
             _logger.LogDebug("Error creating model property for {PropKey}: {EMessage}", propertyKey, e.Message);
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Translates DWSIM internal property keys to human-readable names.
+    /// Example: "PROP_MS_0" -> "Temperature", "PROP_MS_105/Oxygen" -> "Mass Flow (Mixture)/Oxygen"
+    /// https://dwsim.org/wiki/index.php?title=Object_Property_Codes
+    /// </summary>
+    internal string GetHumanReadablePropertyName(string propertyKey)
+    {
+        if (!propertyKey.StartsWith("PROP"))
+            return propertyKey;
+
+        // Mixture properties contain a suffix after a slash (e.g., PROP_MS_105/Oxygen)
+        string[] parts = propertyKey.Split('/', 2);
+        string propCode = parts[0];
+        string? suffix = parts.Length > 1 ? parts[1] : null;
+
+        if (_propMap.TryGetValue(propCode, out string? humanReadableName))
+        {
+            return suffix != null ? $"{humanReadableName}/{suffix}" : humanReadableName;
+        }
+        return propertyKey;
+    }
+
+    /// <summary>
+    /// Gets unit reference information from a COM object for a given property.
+    /// </summary>
+    internal SimulatorValueUnitReference? GetUnitReference(dynamic obj, string propertyKey)
+    {
+        // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_UnitOperations_BaseClass_GetPropertyUnit.htm
+        string unit = obj.GetPropertyUnit(propertyKey) ?? "";
+        if (string.IsNullOrEmpty(unit))
+            return null;
+
+        // Map unit to unit type using DWSIM unit system
+        // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_SystemsOfUnits_Units_GetUnitType.htm
+        string unitType = _unitSystem?.GetUnitType(unit)?.ToString() ?? "";
+        if (unitType == "none" || string.IsNullOrEmpty(unitType))
+            return null;
+
+        return new SimulatorValueUnitReference { Name = unit, Quantity = unitType };
+    }
+
+    /// <summary>
+    /// Converts a raw COM property value to a SimulatorValue.
+    /// Returns null for invalid values (NaN, Infinity, empty arrays, unsupported types).
+    /// </summary>
+    internal SimulatorValue? ConvertToSimulatorValue(dynamic value, string propertyKey)
+    {
+        switch (value)
+        {
+            case double d when double.IsNaN(d) || double.IsInfinity(d):
+            case float f when float.IsNaN(f) || float.IsInfinity(f):
+            case Array { Length: 0 }:
+                return null;
+
+            case double d:
+                return SimulatorValue.Create(d);
+            case float f:
+                return SimulatorValue.Create((double)f);
+            case int i:
+                return SimulatorValue.Create(i);
+            // TODO: Update logic if we extend the API to support boolean type natively
+            case bool b:
+                return SimulatorValue.Create(b ? 1.0 : 0.0);
+            case string s:
+                return SimulatorValue.Create(s);
+
+            case Array arr:
+                // All elements in arrays are of the same type in DWSIM
+                object? first = arr.GetValue(0);
+                if (first is double or float or int)
+                {
+                    double[] doubles = new double[arr.Length];
+                    for (int i = 0; i < arr.Length; i++)
+                        doubles[i] = Convert.ToDouble(arr.GetValue(i));
+                    return SimulatorValue.Create(doubles);
+                }
+                else
+                {
+                    string[] strings = new string[arr.Length];
+                    for (int i = 0; i < arr.Length; i++)
+                        strings[i] = arr.GetValue(i)?.ToString() ?? "";
+                    return SimulatorValue.Create(strings);
+                }
+
+            default:
+                string typeName = value.GetType().Name;
+                _logger.LogDebug("Unsupported value type {ValueType} for property {PropKey}",
+                    typeName, propertyKey);
+                return null;
         }
     }
 }

--- a/Connector/Properties/AssemblyInfo.cs
+++ b/Connector/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Connector.Tests")]


### PR DESCRIPTION
This PR is the forth in a series to incrementally build DWSIM model parsing capabilities. It adds methods to extract node properties from DWSIM COM objects, enabling the connector to read dynamic property values, units, and metadata from DWSIM simulator models.

Next Steps (Upcoming PR)
- PR 5: Full parser integration combining all features