### PR TITLE
Integrate flowsheet extration into the model parser

### DIFF
--- a/Connector.Tests/Dwsim/DwsimModelParserXmlTests.cs
+++ b/Connector.Tests/Dwsim/DwsimModelParserXmlTests.cs
@@ -500,6 +500,59 @@ public class DwsimModelParserXmlTests : IDisposable
 
     #endregion
 
+    #region Parse Method Tests
+
+    [Fact]
+    public void Parse_WithValidShowerMixer_ShouldReturnCompleteFlowsheet()
+    {
+        string dwxmzPath = Path.Combine(_testDataPath, "ShowerMixer.dwxmz");
+        var flowsheet = _parser.Parse(new MockFlowsheetSim(), dwxmzPath, CancellationToken.None);
+
+        Assert.NotNull(flowsheet);
+
+        var nodes = flowsheet.SimulatorObjectNodes.ToList();
+        Assert.Equal(4, nodes.Count);
+        Assert.Contains(nodes, n => n.Id == HotWaterId);
+        Assert.Contains(nodes, n => n.Id == ColdWaterId);
+        Assert.Contains(nodes, n => n.Id == MixerId);
+        Assert.Contains(nodes, n => n.Id == ShowerWaterId);
+        Assert.Equal(3, nodes.Count(n => n.Type == "Material Stream"));
+        Assert.Equal(1, nodes.Count(n => n.Type == "Mixer"));
+        Assert.All(nodes, n => Assert.NotEmpty(n.Properties));
+
+        var edges = flowsheet.SimulatorObjectEdges.ToList();
+        Assert.Equal(3, edges.Count);
+        Assert.Contains(edges, e => e.SourceId == HotWaterId && e.TargetId == MixerId);
+        Assert.Contains(edges, e => e.SourceId == ColdWaterId && e.TargetId == MixerId);
+        Assert.Contains(edges, e => e.SourceId == MixerId && e.TargetId == ShowerWaterId);
+        Assert.All(edges, e =>
+            Assert.Equal(SimulatorModelRevisionDataConnectionType.Material, e.ConnectionType));
+
+        Assert.NotNull(flowsheet.Thermodynamics);
+        Assert.Contains("Water", flowsheet.Thermodynamics.Components);
+        Assert.Contains("Steam Tables (IAPWS-IF97)", flowsheet.Thermodynamics.PropertyPackages);
+    }
+
+    [Fact]
+    public void Parse_WithInvalidFilePath_ShouldReturnNull()
+    {
+        var result = _parser.Parse(new MockFlowsheetSim(), "/nonexistent/model.dwxmz", CancellationToken.None);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Parse_WithCancelledToken_ShouldThrowOperationCanceledException()
+    {
+        string dwxmzPath = Path.Combine(_testDataPath, "ShowerMixer.dwxmz");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            _parser.Parse(new MockFlowsheetSim(), dwxmzPath, cts.Token));
+    }
+
+    #endregion
+
     private class TestableParser(
         ILogger<DwsimClient> logger,
         Dictionary<string, string> propMap,
@@ -514,4 +567,13 @@ public class DwsimModelParserXmlTests : IDisposable
     {
         // Mock unit system for testing without DWSIM dependencies
     }
+}
+
+/// <summary>
+/// Mock flowsheet sim returning null for all COM objects.
+/// Public for cross-assembly dynamic dispatch from DwsimModelParser.
+/// </summary>
+public class MockFlowsheetSim
+{
+    public dynamic? GetFlowsheetSimulationObject(string name) => null;
 }

--- a/Connector/Dwsim/DwsimClient.cs
+++ b/Connector/Dwsim/DwsimClient.cs
@@ -211,7 +211,7 @@ namespace Connector.Dwsim
                             state.ParsingInfo.RevisionDataInfo = [];
                         }
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (e is not OperationCanceledException)
                     {
                         _logger.LogWarning("Flowsheet extraction failed for {ExternalId}, skipping: {Error}",
                             state.ExternalId, e.Message);

--- a/Connector/Dwsim/DwsimClient.cs
+++ b/Connector/Dwsim/DwsimClient.cs
@@ -39,6 +39,7 @@ namespace Connector.Dwsim
         public string Version { get; init; }
         private readonly Dictionary<string, string> _propMap = new Dictionary<string, string>();
         private readonly UnitConverter _unitConverter;
+        private readonly string _dwsimInstallationPath;
 
         // Lock to prevent concurrent access to simulator resources
         private readonly object _simulatorLock = new object();
@@ -48,16 +49,13 @@ namespace Connector.Dwsim
             : base(logger, config.Automation)
         {
             _logger = logger;
-            var dwsimInstallationPath = config.Automation.DwsimInstallationPath;
-            if (dwsimInstallationPath == null)
-            {
-                throw new DwsimException("DWSIM installation path is not set");
-            }
-            string dllPath = Path.Combine(dwsimInstallationPath, "DWSIM.Automation.dll");
+            _dwsimInstallationPath = config.Automation.DwsimInstallationPath
+                ?? throw new DwsimException("DWSIM installation path is not set");
+            string dllPath = Path.Combine(_dwsimInstallationPath, "DWSIM.Automation.dll");
             FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(dllPath);
             Version = fvi.FileVersion != null ? fvi.FileVersion : "N/A";
 
-            string propsDll = Path.Combine(dwsimInstallationPath, "DWSIM.FlowsheetBase.dll");
+            string propsDll = Path.Combine(_dwsimInstallationPath, "DWSIM.FlowsheetBase.dll");
             Assembly assembly = Assembly.LoadFrom(propsDll);
             ResourceManager rm = new ResourceManager("DWSIM.FlowsheetBase.Properties", assembly);
             var resourceSet = rm.GetResourceSet(CultureInfo.InvariantCulture, true, false);
@@ -74,7 +72,7 @@ namespace Connector.Dwsim
                 }
             }
 
-            _unitConverter = new UnitConverter(dwsimInstallationPath);
+            _unitConverter = new UnitConverter(_dwsimInstallationPath);
         }
 
         protected override void PreShutdown()
@@ -158,25 +156,69 @@ namespace Connector.Dwsim
             }
         }
 
-        public Task ExtractModelInformation(DefaultModelFilestate state, CancellationToken _token)
+        /// <summary>
+        /// Extracts the full flowsheet from a DWSIM model file
+        /// </summary>
+        /// <param name="modelFile">The model file state</param>
+        /// <param name="token">Cancellation token</param>
+        /// <returns>Parsed flowsheet or null if parsing fails</returns>
+        private SimulatorModelRevisionDataFlowsheet? ExtractFlowsheet(DefaultModelFilestate modelFile, CancellationToken token)
+        {
+            _logger.LogDebug("Opening model revision {ExternalId} for flowsheet extraction", modelFile.ExternalId);
+            lock (_simulatorLock)
+            {
+                try
+                {
+                    Initialize();
+                    dynamic model = OpenModel(modelFile.FilePath);
+
+                    var modelParser = new DwsimModelParser(_logger, _propMap, _dwsimInstallationPath);
+                    SimulatorModelRevisionDataFlowsheet? flowsheet = modelParser.Parse(model, modelFile.FilePath, token);
+
+                    if (flowsheet == null)
+                    {
+                        _logger.LogWarning("Model parsing returned null for {ExternalId}", modelFile.ExternalId);
+                    }
+
+                    return flowsheet;
+                }
+                finally
+                {
+                    Shutdown();
+                }
+            }
+        }
+
+        public Task ExtractModelInformation(DefaultModelFilestate state, CancellationToken token)
         {
             try
             {
-                bool canRead = CanOpenModel(state.FilePath);
-                state.CanRead = canRead;
-                _logger.LogInformation("{Result} model revision {ExternalId} in DWSIM", canRead ? "Successfully opened" : "Failed to open", state.ExternalId);
-                if (canRead)
+                _logger.LogInformation("Extracting model information for {ExternalId}", state.ExternalId);
+                SimulatorModelRevisionDataFlowsheet? flowsheet = ExtractFlowsheet(state, token);
+
+                if (flowsheet != null)
                 {
+                    state.ParsingInfo.Flowsheets = [flowsheet];
+                    state.ParsingInfo.RevisionDataInfo = [];
+                    state.CanRead = true;
                     state.ParsingInfo.SetSuccess();
+                    _logger.LogInformation("Successfully parsed model revision {ExternalId} in DWSIM", state.ExternalId);
                 }
                 else
                 {
-                    state.ParsingInfo.SetFailure();
+                    state.ParsingInfo.SetFailure("Model parsing returned null");
+                    state.CanRead = false;
                 }
+            }
+            catch (DwsimException de) when (!de.CanRetry)
+            {
+                _logger.LogError("DWSIM error while parsing model {ExternalId}: {Error}", state.ExternalId, de.Message);
+                state.ParsingInfo.SetFailure(de.Message);
+                state.CanRead = false;
             }
             catch (Exception e)
             {
-                _logger.LogError("Error while opening revision {ExternalId}: {Error}", state.ExternalId, e.Message);
+                _logger.LogWarning("Error parsing model {ExternalId}, will retry: {Error}", state.ExternalId, e.Message);
                 state.ParsingInfo.SetFailure();
                 state.CanRead = false;
             }

--- a/Connector/Dwsim/DwsimClient.cs
+++ b/Connector/Dwsim/DwsimClient.cs
@@ -193,32 +193,44 @@ namespace Connector.Dwsim
         {
             try
             {
-                _logger.LogInformation("Extracting model information for {ExternalId}", state.ExternalId);
-                SimulatorModelRevisionDataFlowsheet? flowsheet = ExtractFlowsheet(state, token);
+                bool canRead = CanOpenModel(state.FilePath);
+                state.CanRead = canRead;
+                _logger.LogInformation("{Result} model revision {ExternalId} in DWSIM",
+                    canRead ? "Successfully opened" : "Failed to open", state.ExternalId);
 
-                if (flowsheet != null)
+                if (canRead)
                 {
-                    state.ParsingInfo.Flowsheets = [flowsheet];
-                    state.ParsingInfo.RevisionDataInfo = [];
-                    state.CanRead = true;
                     state.ParsingInfo.SetSuccess();
-                    _logger.LogInformation("Successfully parsed model revision {ExternalId} in DWSIM", state.ExternalId);
+
+                    try
+                    {
+                        var flowsheet = ExtractFlowsheet(state, token);
+                        if (flowsheet != null)
+                        {
+                            state.ParsingInfo.Flowsheets = [flowsheet];
+                            state.ParsingInfo.RevisionDataInfo = [];
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogWarning("Flowsheet extraction failed for {ExternalId}, skipping: {Error}",
+                            state.ExternalId, e.Message);
+                    }
                 }
                 else
                 {
-                    state.ParsingInfo.SetFailure("Model parsing returned null");
-                    state.CanRead = false;
+                    state.ParsingInfo.SetFailure();
                 }
             }
             catch (DwsimException de) when (!de.CanRetry)
             {
-                _logger.LogError("DWSIM error while parsing model {ExternalId}: {Error}", state.ExternalId, de.Message);
+                _logger.LogError("DWSIM error while opening model {ExternalId}: {Error}", state.ExternalId, de.Message);
                 state.ParsingInfo.SetFailure(de.Message);
                 state.CanRead = false;
             }
             catch (Exception e)
             {
-                _logger.LogWarning("Error parsing model {ExternalId}, will retry: {Error}", state.ExternalId, e.Message);
+                _logger.LogError("Error while opening revision {ExternalId}: {Error}", state.ExternalId, e.Message);
                 state.ParsingInfo.SetFailure();
                 state.CanRead = false;
             }

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -18,6 +18,8 @@ using System.Collections;
 using System.Globalization;
 using System.IO.Compression;
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using System.Xml.Linq;
 using CogniteSdk.Alpha;
 using Microsoft.Extensions.Logging;
@@ -133,11 +135,15 @@ public class DwsimModelParser
 
             // Generate edges from XML connections
             _logger.LogDebug("Generating flowsheet edges");
-            IEnumerable<SimulatorModelRevisionDataObjectEdge> edges = GenerateFlowsheetEdgesFromXml(doc, nodes, _logger);
+            IEnumerable<SimulatorModelRevisionDataObjectEdge> edges = GenerateFlowsheetEdgesFromXml(doc, nodes, _logger, _modelParsingConfig);
+
+            // Ensure at least one edge exists
+            // TODO: Remove EnsureAtLeastOneEdge call when API lifts the minItems restriction
+            edges = EnsureAtLeastOneEdge(edges, nodes);
 
             // Extract thermodynamic data
             _logger.LogDebug("Extracting thermodynamic data");
-            SimulatorModelRevisionDataThermodynamic thermodynamics = ExtractThermodynamicDataFromXml(doc, _logger);
+            SimulatorModelRevisionDataThermodynamic thermodynamics = ExtractThermodynamicDataFromXml(doc, _logger, _modelParsingConfig);
 
             var flowsheet = new SimulatorModelRevisionDataFlowsheet
             {
@@ -311,7 +317,7 @@ public class DwsimModelParser
                     graphicObjectLookup.TryGetValue(objName, out XElement? graphicObj);
 
                     // Create node from XML
-                    SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, _logger);
+                    SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, _logger, _modelParsingConfig);
                     if (node == null)
                         continue;
 
@@ -335,6 +341,10 @@ public class DwsimModelParser
                             _logger.LogDebug("Could not extract properties for {ObjName}: {EMessage}", objName, ex.Message);
                         }
                     }
+
+                    // Ensure at least one property exists for each node
+                    // TODO: Remove EnsureAtLeastOneProperty call when API lifts the minItems restriction
+                    node.Properties = EnsureAtLeastOneProperty(node.Properties?.ToList() ?? []);
 
                     nodes.Add(node);
                 }
@@ -361,9 +371,15 @@ public class DwsimModelParser
     /// </summary>
     /// <param name="doc">Parsed XML document</param>
     /// <param name="logger">Logger for diagnostic messages</param>
+    /// <param name="config">Optional parsing configuration for length limits</param>
     /// <returns>List of parsed nodes</returns>
-    public static List<SimulatorModelRevisionDataObjectNode> ParseNodesFromXml(XDocument doc, ILogger? logger = null)
+    public static List<SimulatorModelRevisionDataObjectNode> ParseNodesFromXml(
+        XDocument doc,
+        ILogger? logger = null,
+        DwsimModelParsingConfig? config = null)
     {
+        config ??= new DwsimModelParsingConfig();
+
         var nodes = new List<SimulatorModelRevisionDataObjectNode>();
 
         try
@@ -396,7 +412,7 @@ public class DwsimModelParser
                     // Find corresponding graphic object
                     graphicObjectLookup.TryGetValue(objName, out XElement? graphicObj);
 
-                    SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, logger);
+                    SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, logger, config);
                     if (node != null)
                         nodes.Add(node);
                 }
@@ -420,9 +436,16 @@ public class DwsimModelParser
     /// <param name="simObj">Simulation object XML element</param>
     /// <param name="graphicObj">Graphic object XML element</param>
     /// <param name="logger">Logger for diagnostic messages</param>
+    /// <param name="config">Optional parsing configuration for length limits</param>
     /// <returns>Created node or null if creation fails</returns>
-    public static SimulatorModelRevisionDataObjectNode? CreateNodeFromXml(XElement simObj, XElement? graphicObj, ILogger? logger = null)
+    public static SimulatorModelRevisionDataObjectNode? CreateNodeFromXml(
+        XElement simObj,
+        XElement? graphicObj,
+        ILogger? logger = null,
+        DwsimModelParsingConfig? config = null)
     {
+        config ??= new DwsimModelParsingConfig();
+
         try
         {
             // Get basic object information from XML
@@ -437,12 +460,17 @@ public class DwsimModelParser
             // Normalize stream types to standardized names (e.g., "MaterialStream" -> "Material Stream")
             string normalizedType = NormalizeStreamType(objectType);
 
+            // Apply API length limits to ID, Name, and Type
+            string safeId = EnsureMaxLength(objectId, config.MaxNodeIdLength);
+            string? safeName = objectName != null ? EnsureMaxLength(objectName, config.MaxNodeNameLength) : null;
+            string safeType = EnsureMaxLength(normalizedType, config.MaxNodeTypeLength);
+
             // Create node with basic information
             var node = new SimulatorModelRevisionDataObjectNode
             {
-                Id = objectId,
-                Name = objectName,
-                Type = normalizedType,
+                Id = safeId,
+                Name = safeName,
+                Type = safeType,
                 Properties = new List<SimulatorModelRevisionDataProperty>(),
                 GraphicalObject = CreateGraphicalObjectFromXml(graphicObj)
             };
@@ -462,12 +490,16 @@ public class DwsimModelParser
     /// <param name="doc">Parsed XML document</param>
     /// <param name="nodes">List of parsed nodes to reference for edge creation</param>
     /// <param name="logger">Logger for diagnostic messages</param>
+    /// <param name="config">Optional parsing configuration for length limits</param>
     /// <returns>Collection of edges representing connections between nodes</returns>
     public static IEnumerable<SimulatorModelRevisionDataObjectEdge> GenerateFlowsheetEdgesFromXml(
         XDocument doc,
         List<SimulatorModelRevisionDataObjectNode> nodes,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        DwsimModelParsingConfig? config = null)
     {
+        config ??= new DwsimModelParsingConfig();
+
         if (nodes == null || nodes.Count == 0)
             return [];
 
@@ -499,7 +531,12 @@ public class DwsimModelParser
                 try
                 {
                     string? sourceName = graphicObj.Element("Name")?.Value;
-                    if (string.IsNullOrEmpty(sourceName) || !nodesByName.TryGetValue(sourceName, out SimulatorModelRevisionDataObjectNode? sourceNode))
+                    if (string.IsNullOrEmpty(sourceName))
+                        continue;
+
+                    // Apply EnsureMaxLength to lookup key to match processed node IDs
+                    string safeSourceName = EnsureMaxLength(sourceName, config.MaxNodeIdLength);
+                    if (!nodesByName.TryGetValue(safeSourceName, out SimulatorModelRevisionDataObjectNode? sourceNode))
                         continue;
 
                     // Parse output connections from XML
@@ -513,16 +550,26 @@ public class DwsimModelParser
                             continue;
 
                         string? connectedId = connector.Attribute("AttachedToObjID")?.Value;
-                        if (string.IsNullOrEmpty(connectedId) || !nodesByName.TryGetValue(connectedId, out SimulatorModelRevisionDataObjectNode? targetNode))
+                        if (string.IsNullOrEmpty(connectedId))
+                            continue;
+
+                        // Apply EnsureMaxLength to lookup key to match processed node IDs
+                        string safeConnectedId = EnsureMaxLength(connectedId, config.MaxNodeIdLength);
+                        if (!nodesByName.TryGetValue(safeConnectedId, out SimulatorModelRevisionDataObjectNode? targetNode))
                             continue;
 
                         SimulatorModelRevisionDataConnectionType connectionType = DetermineConnectionType(sourceNode, targetNode);
+
+                        // Use the actual node IDs (which are already safe/processed) for edge references
+                        // Apply API length limit to edge ID
+                        string edgeId = EnsureMaxLength($"{sourceNode.Id}_{targetNode.Id}", config.MaxEdgeIdLength);
+
                         var edge = new SimulatorModelRevisionDataObjectEdge
                         {
-                            Id = $"{sourceName}_{connectedId}",
+                            Id = edgeId,
                             Name = $"{sourceNode.Name} -> {targetNode.Name}",
-                            SourceId = sourceName,
-                            TargetId = connectedId,
+                            SourceId = sourceNode.Id,
+                            TargetId = targetNode.Id,
                             ConnectionType = connectionType
                         };
                         edges.Add(edge);
@@ -633,15 +680,21 @@ public class DwsimModelParser
     /// </summary>
     /// <param name="doc">Parsed XML document</param>
     /// <param name="logger">Logger for diagnostic messages</param>
+    /// <param name="config">Optional parsing configuration for length limits</param>
     /// <returns>Thermodynamic data containing components and property packages</returns>
-    public static SimulatorModelRevisionDataThermodynamic ExtractThermodynamicDataFromXml(XDocument doc, ILogger? logger = null)
+    public static SimulatorModelRevisionDataThermodynamic ExtractThermodynamicDataFromXml(
+        XDocument doc,
+        ILogger? logger = null,
+        DwsimModelParsingConfig? config = null)
     {
+        config ??= new DwsimModelParsingConfig();
+
         var components = new List<string>();
         var propertyPackages = new List<string>();
 
         try
         {
-            // Extract components from Compounds section
+            // Extract components from Compounds section (apply API length limits)
             IEnumerable<XElement>? compoundElements = doc.Root?.Element("Compounds")?.Elements("Compound");
             if (compoundElements != null)
             {
@@ -649,7 +702,7 @@ public class DwsimModelParser
                 {
                     string? componentName = compound.Element("Name")?.Value;
                     if (!string.IsNullOrEmpty(componentName))
-                        components.Add(componentName);
+                        components.Add(EnsureMaxLength(componentName, config.MaxThermodynamicStringLength));
                 }
             }
 
@@ -661,7 +714,7 @@ public class DwsimModelParser
                 {
                     string? packageName = package.Element("ComponentName")?.Value;
                     if (!string.IsNullOrEmpty(packageName))
-                        propertyPackages.Add(packageName);
+                        propertyPackages.Add(EnsureMaxLength(packageName, config.MaxThermodynamicStringLength));
                 }
             }
 
@@ -772,9 +825,12 @@ public class DwsimModelParser
 
             bool isReadOnly = writeProperties is null || !((IList)writeProperties).Contains(propertyKey);
 
+            // Apply API length limit to property name
+            string safeName = EnsureMaxLength(GetHumanReadablePropertyName(propertyKey), _modelParsingConfig.MaxPropertyNameLength);
+
             return new SimulatorModelRevisionDataProperty
             {
-                Name = GetHumanReadablePropertyName(propertyKey),
+                Name = safeName,
                 ValueType = simulatorValue.Type,
                 Value = simulatorValue,
                 Unit = GetUnitReference(obj, propertyKey),
@@ -893,13 +949,113 @@ public class DwsimModelParser
                 return null;
         }
     }
+
+    #region API Constraints
+
+    /// <summary>
+    /// Ensures a string is at most maxLength characters long. If longer, creates a SHA256 hash.
+    /// </summary>
+    /// <param name="value">The string to check</param>
+    /// <param name="maxLength">Maximum allowed length</param>
+    /// <returns>Original string if within limit, otherwise a hash of the string</returns>
+    private static string EnsureMaxLength(string value, int maxLength)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= maxLength)
+            return value;
+
+        // Create a hash of the full value to ensure uniqueness
+        byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+
+        // Convert to base64 and remove special characters to make it URL-safe
+        string hash = Convert.ToBase64String(hashBytes)
+            .Replace("+", "")
+            .Replace("/", "")
+            .Replace("=", "");
+
+        // Take first maxLength characters of the hash (ensures uniqueness)
+        return hash[..Math.Min(hash.Length, maxLength)];
+    }
+
+    /// <summary>
+    /// Ensures at least one property exists for a node.
+    /// TODO: Remove this workaround when API lifts the minItems restriction on properties.
+    /// </summary>
+    /// <param name="properties">The list of properties to check</param>
+    /// <returns>Original list if not empty, otherwise a list with a placeholder property</returns>
+    private static List<SimulatorModelRevisionDataProperty> EnsureAtLeastOneProperty(
+        List<SimulatorModelRevisionDataProperty> properties)
+    {
+        if (properties.Count > 0)
+            return properties;
+
+        // Add a placeholder property when no properties exist
+        properties.Add(new SimulatorModelRevisionDataProperty
+        {
+            Name = "_placeholder",
+            ValueType = SimulatorValueType.STRING,
+            Value = SimulatorValue.Create("No properties available"),
+            ReadOnly = true,
+            ReferenceObject = new Dictionary<string, string>
+            {
+                { "objectType", "Placeholder" },
+                { "objectName", "Placeholder" },
+                { "objectProperty", "_placeholder" }
+            }
+        });
+
+        return properties;
+    }
+
+    /// <summary>
+    /// Ensures at least one edge exists in the flowsheet.
+    /// TODO: Remove this workaround when API lifts the minItems restriction on edges.
+    /// </summary>
+    /// <param name="edges">The collection of edges to check</param>
+    /// <param name="nodes">The list of nodes (used to create placeholder edge if needed)</param>
+    /// <returns>Original edges if not empty, otherwise a collection with a placeholder edge</returns>
+    private static IEnumerable<SimulatorModelRevisionDataObjectEdge> EnsureAtLeastOneEdge(
+        IEnumerable<SimulatorModelRevisionDataObjectEdge> edges,
+        List<SimulatorModelRevisionDataObjectNode> nodes)
+    {
+        List<SimulatorModelRevisionDataObjectEdge> edgeList = edges.ToList();
+        if (edgeList.Count > 0)
+            return edgeList;
+
+        // Create a placeholder edge using the first node (self-referential)
+        if (nodes.Count > 0 && nodes[0].Id != null)
+        {
+            edgeList.Add(new SimulatorModelRevisionDataObjectEdge
+            {
+                Id = "_placeholder",
+                Name = "Placeholder Edge",
+                SourceId = nodes[0].Id,
+                TargetId = nodes[0].Id,
+                ConnectionType = SimulatorModelRevisionDataConnectionType.Information
+            });
+        }
+
+        return edgeList;
+    }
+
+    #endregion
 }
 
 /// <summary>
-/// Configuration class for DWSIM model parsing
+/// Configuration class for DWSIM model parsing.
+/// Default values are based on the Simulators API constraints.
 /// </summary>
 public class DwsimModelParsingConfig
 {
-    // will be used later when we start to extract node properties
+    // Item count limits
+    public int MaxNodesPerFlowsheet { get; set; } = 2000;
+    public int MaxEdgesPerFlowsheet { get; set; } = 2000;
     public int MaxPropertiesPerNode { get; set; } = 100;
+
+    // Character length limits for identifiers and names
+    public int MaxNodeIdLength { get; set; } = 50;
+    public int MaxNodeNameLength { get; set; } = 50;
+    public int MaxNodeTypeLength { get; set; } = 50;
+    public int MaxEdgeIdLength { get; set; } = 50;
+    public int MaxPropertyNameLength { get; set; } = 50;
+    public int MaxThermodynamicStringLength { get; set; } = 50;
 }

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -120,28 +120,22 @@ public class DwsimModelParser
 
         try
         {
-            // Validate the provided file path
             if (!ValidateFilePath(filePath))
                 return null;
 
-            // Extract XML from DWXMZ file
             xmlFilePath = ExtractXmlFromDwxmz(filePath);
             XDocument doc = XDocument.Load(xmlFilePath);
 
-            // Parse nodes with COM property extraction
             _logger.LogDebug("Parsing simulation objects with properties");
             List<SimulatorModelRevisionDataObjectNode> nodes = ParseNodesWithProperties(doc, sim, token);
             _logger.LogDebug("Extracted {NodesCount} nodes from the model", nodes.Count);
 
-            // Generate edges from XML connections
             _logger.LogDebug("Generating flowsheet edges");
             IEnumerable<SimulatorModelRevisionDataObjectEdge> edges = GenerateFlowsheetEdgesFromXml(doc, nodes, _logger, _modelParsingConfig);
 
-            // Ensure at least one edge exists
             // TODO: Remove EnsureAtLeastOneEdge call when API lifts the minItems restriction
             edges = EnsureAtLeastOneEdge(edges, nodes);
 
-            // Extract thermodynamic data
             _logger.LogDebug("Extracting thermodynamic data");
             SimulatorModelRevisionDataThermodynamic thermodynamics = ExtractThermodynamicDataFromXml(doc, _logger, _modelParsingConfig);
 
@@ -167,7 +161,6 @@ public class DwsimModelParser
         }
         finally
         {
-            // Always cleanup temporary files
             if (!string.IsNullOrEmpty(xmlFilePath))
                 CleanupTempFiles(xmlFilePath);
         }
@@ -189,10 +182,8 @@ public class DwsimModelParser
 
         try
         {
-            // Extract the DWXMZ file
             ZipFile.ExtractToDirectory(filePath, tempDir);
 
-            // Find the XML file
             string[] xmlFiles = Directory.GetFiles(tempDir, "*.xml");
             if (xmlFiles.Length == 0)
                 throw new FileNotFoundException("No XML file found in DWXMZ archive");
@@ -202,7 +193,6 @@ public class DwsimModelParser
         }
         catch
         {
-            // Clean up on error
             if (Directory.Exists(tempDir))
                 Directory.Delete(tempDir, true);
             throw;
@@ -273,15 +263,12 @@ public class DwsimModelParser
 
         try
         {
-            // Parse SimulationObjects from XML
             List<XElement> simObjects = doc.Root?.Element("SimulationObjects")?.Elements("SimulationObject").ToList() ?? [];
             _logger.LogDebug("Found {Count} simulation objects in XML", simObjects.Count);
 
-            // Parse GraphicObjects from XML
             List<XElement> graphicObjects = doc.Root?.Element("GraphicObjects")?.Elements("GraphicObject").ToList() ?? [];
             _logger.LogDebug("Found {Count} graphic objects in XML", graphicObjects.Count);
 
-            // Create a lookup for graphic objects by Name
             Dictionary<string, XElement> graphicObjectLookup = graphicObjects
                 .Where(g => g.Element("Name")?.Value != null)
                 .GroupBy(g => g.Element("Name")!.Value)
@@ -302,10 +289,8 @@ public class DwsimModelParser
                         continue;
                     }
 
-                    // Find corresponding graphic object
                     graphicObjectLookup.TryGetValue(objName, out XElement? graphicObj);
 
-                    // Create node from XML
                     SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, _logger, _modelParsingConfig);
                     if (node == null)
                         continue;
@@ -319,7 +304,6 @@ public class DwsimModelParser
                         dynamic? comObject = sim.GetFlowsheetSimulationObject(nodeName);
                         if (comObject != null)
                         {
-                            // Update object type using ProductName (human-friendly name) if available
                             try
                             {
                                 string? productName = comObject.ProductName?.ToString();
@@ -347,7 +331,6 @@ public class DwsimModelParser
                         _logger.LogDebug("Could not extract properties for {NodeName}: {EMessage}", nodeName, ex.Message);
                     }
 
-                    // Ensure at least one property exists for each node
                     // TODO: Remove EnsureAtLeastOneProperty call when API lifts the minItems restriction
                     node.Properties = EnsureAtLeastOneProperty(node.Properties?.ToList() ?? []);
 
@@ -389,13 +372,10 @@ public class DwsimModelParser
 
         try
         {
-            // Parse SimulationObjects - only direct children of SimulationObjects element
             List<XElement> simObjects = doc.Root?.Element("SimulationObjects")?.Elements("SimulationObject").ToList() ?? [];
 
-            // Parse GraphicObjects - scope to GraphicObjects parent element
             List<XElement> graphicObjects = doc.Root?.Element("GraphicObjects")?.Elements("GraphicObject").ToList() ?? [];
 
-            // Create a lookup for graphic objects by Name, handling duplicates by taking first occurrence
             Dictionary<string, XElement> graphicObjectLookup = graphicObjects
                 .Where(g => g.Element("Name")?.Value != null)
                 .GroupBy(g => g.Element("Name")!.Value)
@@ -414,7 +394,6 @@ public class DwsimModelParser
                         continue;
                     }
 
-                    // Find corresponding graphic object
                     graphicObjectLookup.TryGetValue(objName, out XElement? graphicObj);
 
                     SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, logger, config);
@@ -453,24 +432,20 @@ public class DwsimModelParser
 
         try
         {
-            // Get basic object information from XML
             string? objectId = simObj.Element("ComponentName")?.Value ?? simObj.Element("Name")?.Value;
             string? objectType = simObj.Element("Type")?.Value?.Split('.').LastOrDefault();
             string? objectName = graphicObj?.Element("Tag")?.Value ?? objectId;
 
-            // Skip nodes without required properties
             if (string.IsNullOrEmpty(objectId) || string.IsNullOrEmpty(objectType))
                 return null;
 
             // Normalize stream types to standardized names (e.g., "MaterialStream" -> "Material Stream")
             string normalizedType = NormalizeStreamType(objectType);
 
-            // Apply API length limits to ID, Name, and Type
             string safeId = EnsureMaxLength(objectId, config.MaxNodeIdLength);
             string? safeName = objectName != null ? EnsureMaxLength(objectName, config.MaxNodeNameLength) : null;
             string safeType = EnsureMaxLength(normalizedType, config.MaxNodeTypeLength);
 
-            // Create node with basic information
             var node = new SimulatorModelRevisionDataObjectNode
             {
                 Id = safeId,
@@ -544,7 +519,6 @@ public class DwsimModelParser
                     if (!nodesByName.TryGetValue(safeSourceName, out SimulatorModelRevisionDataObjectNode? sourceNode))
                         continue;
 
-                    // Parse output connections from XML
                     IEnumerable<XElement>? outputConnectors = graphicObj.Element("OutputConnectors")?.Elements("Connector");
                     if (outputConnectors == null)
                         continue;
@@ -565,8 +539,6 @@ public class DwsimModelParser
 
                         SimulatorModelRevisionDataConnectionType connectionType = DetermineConnectionType(sourceNode, targetNode);
 
-                        // Use the actual node IDs (which are already safe/processed) for edge references
-                        // Apply API length limit to edge ID
                         string edgeId = EnsureMaxLength($"{sourceNode.Id}_{targetNode.Id}", config.MaxEdgeIdLength);
 
                         var edge = new SimulatorModelRevisionDataObjectEdge
@@ -586,7 +558,6 @@ public class DwsimModelParser
                 }
             }
 
-            // Remove duplicate edges
             edges = RemoveDuplicateEdges(edges, logger);
             logger?.LogDebug("Generated {EdgesCount} edges from XML connections", edges.Count);
         }
@@ -605,15 +576,12 @@ public class DwsimModelParser
         SimulatorModelRevisionDataObjectNode sourceNode,
         SimulatorModelRevisionDataObjectNode targetNode)
     {
-        // Check if it's an energy stream
         if (sourceNode.Type == StandardEnergyStreamType || targetNode.Type == StandardEnergyStreamType)
             return SimulatorModelRevisionDataConnectionType.Energy;
 
-        // Check if it's a material stream
         if (sourceNode.Type == StandardMaterialStreamType || targetNode.Type == StandardMaterialStreamType)
             return SimulatorModelRevisionDataConnectionType.Material;
 
-        // Default to information for other connections
         return SimulatorModelRevisionDataConnectionType.Information;
     }
 
@@ -648,7 +616,6 @@ public class DwsimModelParser
         if (graphicObj == null)
             return null;
 
-        // Only create position if both X and Y are present and can be parsed
         SimulatorModelRevisionDataPosition? position = null;
         string? xElement = graphicObj.Element("X")?.Value;
         string? yElement = graphicObj.Element("Y")?.Value;
@@ -699,7 +666,6 @@ public class DwsimModelParser
 
         try
         {
-            // Extract components from Compounds section (apply API length limits)
             IEnumerable<XElement>? compoundElements = doc.Root?.Element("Compounds")?.Elements("Compound");
             if (compoundElements != null)
             {
@@ -711,7 +677,6 @@ public class DwsimModelParser
                 }
             }
 
-            // Extract property packages from PropertyPackages section
             IEnumerable<XElement>? propertyPackageElements = doc.Root?.Element("PropertyPackages")?.Elements("PropertyPackage");
             if (propertyPackageElements != null)
             {
@@ -760,7 +725,6 @@ public class DwsimModelParser
             dynamic? writeProperties = obj.GetProperties(1);
             dynamic? readProperties = obj.GetProperties(3);
 
-            // Combine all properties, avoiding duplicates
             var allProperties = new HashSet<string>();
             if (writeProperties != null)
                 foreach (string prop in writeProperties) allProperties.Add(prop);
@@ -818,7 +782,6 @@ public class DwsimModelParser
     {
         try
         {
-            // Get property value from COM object
             // https://dwsim.org/api_help/html/M_DWSIM_SharedClasses_UnitOperations_BaseClass_GetPropertyValue.htm
             dynamic value = obj.GetPropertyValue(propertyKey);
             if (value == null)
@@ -830,7 +793,6 @@ public class DwsimModelParser
 
             bool isReadOnly = writeProperties is null || !((IList)writeProperties).Contains(propertyKey);
 
-            // Apply API length limit to property name
             string safeName = EnsureMaxLength(GetHumanReadablePropertyName(propertyKey) ?? propertyKey, _modelParsingConfig.MaxPropertyNameLength);
 
             return new SimulatorModelRevisionDataProperty
@@ -993,7 +955,6 @@ public class DwsimModelParser
         if (properties.Count > 0)
             return properties;
 
-        // Add a placeholder property when no properties exist
         properties.Add(new SimulatorModelRevisionDataProperty
         {
             Name = "_placeholder",
@@ -1026,7 +987,6 @@ public class DwsimModelParser
         if (edgeList.Count > 0)
             return edgeList;
 
-        // Create a placeholder edge using the first node (self-referential)
         if (nodes.Count > 0 && nodes[0].Id != null)
         {
             edgeList.Add(new SimulatorModelRevisionDataObjectEdge

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -102,6 +102,72 @@ public class DwsimModelParser
     }
 
     /// <summary>
+    /// Parses the DWSIM model and returns the flowsheet as SimulatorModelRevisionDataFlowsheet.
+    /// This is the main orchestration method that combines XML parsing, COM property extraction,
+    /// edge generation, and thermodynamic data extraction.
+    /// </summary>
+    /// <param name="sim">The DWSIM flowsheet COM object</param>
+    /// <param name="filePath">Path to the DWXMZ file</param>
+    /// <param name="token">Cancellation token</param>
+    /// <returns>Flowsheet object or null if parsing fails</returns>
+    public virtual SimulatorModelRevisionDataFlowsheet? Parse(dynamic sim, string filePath, CancellationToken token)
+    {
+        _logger.LogDebug("DWSIM model parsing started for: {FilePath}", filePath);
+
+        string? xmlFilePath = null;
+
+        try
+        {
+            // Validate the provided file path
+            if (!ValidateFilePath(filePath))
+                return null;
+
+            // Extract XML from DWXMZ file
+            xmlFilePath = ExtractXmlFromDwxmz(filePath);
+            XDocument doc = XDocument.Load(xmlFilePath);
+
+            // Parse nodes with COM property extraction
+            _logger.LogDebug("Parsing simulation objects with properties");
+            List<SimulatorModelRevisionDataObjectNode> nodes = ParseNodesWithProperties(doc, sim, token);
+            _logger.LogDebug("Extracted {NodesCount} nodes from the model", nodes.Count);
+
+            // Generate edges from XML connections
+            _logger.LogDebug("Generating flowsheet edges");
+            IEnumerable<SimulatorModelRevisionDataObjectEdge> edges = GenerateFlowsheetEdgesFromXml(doc, nodes, _logger);
+
+            // Extract thermodynamic data
+            _logger.LogDebug("Extracting thermodynamic data");
+            SimulatorModelRevisionDataThermodynamic thermodynamics = ExtractThermodynamicDataFromXml(doc, _logger);
+
+            var flowsheet = new SimulatorModelRevisionDataFlowsheet
+            {
+                SimulatorObjectNodes = nodes,
+                SimulatorObjectEdges = edges,
+                Thermodynamics = thermodynamics
+            };
+
+            _logger.LogDebug("DWSIM model parsing completed successfully");
+            return flowsheet;
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Model parsing was cancelled");
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Error while parsing DWSIM model: {EMessage}", e.Message);
+            return null;
+        }
+        finally
+        {
+            // Always cleanup temporary files
+            if (!string.IsNullOrEmpty(xmlFilePath))
+                CleanupTempFiles(xmlFilePath);
+        }
+    }
+
+    /// <summary>
     /// Extracts XML file from DWXMZ archive
     /// </summary>
     /// <param name="filePath">Path to the DWXMZ file</param>
@@ -188,7 +254,110 @@ public class DwsimModelParser
     }
 
     /// <summary>
-    /// Parses nodes from XML document
+    /// Parses nodes from XML document and extracts properties from COM objects.
+    /// This is an instance method that combines XML parsing with COM property extraction.
+    /// </summary>
+    /// <param name="doc">Parsed XML document</param>
+    /// <param name="sim">DWSIM flowsheet COM object</param>
+    /// <param name="token">Cancellation token</param>
+    /// <returns>List of parsed nodes with properties</returns>
+    private List<SimulatorModelRevisionDataObjectNode> ParseNodesWithProperties(XDocument doc, dynamic sim, CancellationToken token)
+    {
+        var nodes = new List<SimulatorModelRevisionDataObjectNode>();
+
+        try
+        {
+            // Parse SimulationObjects from XML
+            List<XElement> simObjects = doc.Root?.Element("SimulationObjects")?.Elements("SimulationObject").ToList() ?? [];
+            _logger.LogDebug("Found {Count} simulation objects in XML", simObjects.Count);
+
+            // Parse GraphicObjects from XML
+            List<XElement> graphicObjects = doc.Root?.Element("GraphicObjects")?.Elements("GraphicObject").ToList() ?? [];
+            _logger.LogDebug("Found {Count} graphic objects in XML", graphicObjects.Count);
+
+            // Create a lookup for graphic objects by Name
+            Dictionary<string, XElement> graphicObjectLookup = graphicObjects
+                .Where(g => g.Element("Name")?.Value != null)
+                .GroupBy(g => g.Element("Name")!.Value)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            // Get simulation objects dictionary from COM model for property extraction
+            dynamic? simObjectsDict = null;
+            try
+            {
+                simObjectsDict = sim.SimulationObjects;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning("Could not access SimulationObjects from COM model: {EMessage}", ex.Message);
+            }
+
+            foreach (XElement simObj in simObjects)
+            {
+                token.ThrowIfCancellationRequested();
+
+                try
+                {
+                    string? objName = simObj.Element("ComponentName")?.Value ??
+                                     simObj.Element("Name")?.Value;
+
+                    if (string.IsNullOrEmpty(objName))
+                    {
+                        _logger.LogDebug("Skipping simulation object without ComponentName or Name");
+                        continue;
+                    }
+
+                    // Find corresponding graphic object
+                    graphicObjectLookup.TryGetValue(objName, out XElement? graphicObj);
+
+                    // Create node from XML
+                    SimulatorModelRevisionDataObjectNode? node = CreateNodeFromXml(simObj, graphicObj, _logger);
+                    if (node == null)
+                        continue;
+
+                    // Extract properties from COM object if available
+                    if (simObjectsDict != null)
+                    {
+                        try
+                        {
+                            dynamic comObject = simObjectsDict[objName];
+                            if (comObject != null)
+                            {
+                                List<SimulatorModelRevisionDataProperty> properties =
+                                    ExtractNodePropertiesFromCom(comObject, node.Type ?? "Unknown", node.Name ?? objName);
+                                node.Properties = properties;
+                                _logger.LogDebug("Extracted {PropCount} properties for node {NodeName}",
+                                    properties.Count, node.Name);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogDebug("Could not extract properties for {ObjName}: {EMessage}", objName, ex.Message);
+                        }
+                    }
+
+                    nodes.Add(node);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse simulation object, skipping node");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to parse nodes with properties");
+        }
+
+        return nodes;
+    }
+
+    /// <summary>
+    /// Parses nodes from XML document (static, XML-only version without COM property extraction)
     /// </summary>
     /// <param name="doc">Parsed XML document</param>
     /// <param name="logger">Logger for diagnostic messages</param>

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -287,17 +287,6 @@ public class DwsimModelParser
                 .GroupBy(g => g.Element("Name")!.Value)
                 .ToDictionary(g => g.Key, g => g.First());
 
-            // Get simulation objects dictionary from COM model for property extraction
-            dynamic? simObjectsDict = null;
-            try
-            {
-                simObjectsDict = sim.SimulationObjects;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning("Could not access SimulationObjects from COM model: {EMessage}", ex.Message);
-            }
-
             foreach (XElement simObj in simObjects)
             {
                 token.ThrowIfCancellationRequested();
@@ -321,25 +310,41 @@ public class DwsimModelParser
                     if (node == null)
                         continue;
 
-                    // Extract properties from COM object if available
-                    if (simObjectsDict != null)
+                    // Extract properties from COM object using GetFlowsheetSimulationObject
+                    // This method takes the Tag (display name) as parameter, not the internal ComponentName
+                    // https://dwsim.org/api_help/html/M_DWSIM_Interfaces_IFlowsheet_GetFlowsheetSimulationObject.htm
+                    string nodeName = node.Name ?? objName;
+                    try
                     {
-                        try
+                        dynamic? comObject = sim.GetFlowsheetSimulationObject(nodeName);
+                        if (comObject != null)
                         {
-                            dynamic comObject = simObjectsDict[objName];
-                            if (comObject != null)
+                            // Update object type using ProductName (human-friendly name) if available
+                            try
                             {
-                                List<SimulatorModelRevisionDataProperty> properties =
-                                    ExtractNodePropertiesFromCom(comObject, node.Type ?? "Unknown", node.Name ?? objName);
-                                node.Properties = properties;
-                                _logger.LogDebug("Extracted {PropCount} properties for node {NodeName}",
-                                    properties.Count, node.Name);
+                                string? productName = comObject.ProductName?.ToString();
+                                if (!string.IsNullOrEmpty(productName))
+                                    node.Type = EnsureMaxLength(productName, _modelParsingConfig.MaxNodeTypeLength);
                             }
+                            catch (Exception ex)
+                            {
+                                _logger.LogDebug("Could not get ProductName for {NodeName}: {EMessage}", nodeName, ex.Message);
+                            }
+
+                            List<SimulatorModelRevisionDataProperty> properties =
+                                ExtractNodePropertiesFromCom(comObject, node.Type ?? "Unknown", nodeName);
+                            node.Properties = properties;
+                            _logger.LogDebug("Extracted {PropCount} properties for node {NodeName}",
+                                properties.Count, nodeName);
                         }
-                        catch (Exception ex)
+                        else
                         {
-                            _logger.LogDebug("Could not extract properties for {ObjName}: {EMessage}", objName, ex.Message);
+                            _logger.LogWarning("Could not get COM object for {NodeName}", nodeName);
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug("Could not extract properties for {NodeName}: {EMessage}", nodeName, ex.Message);
                     }
 
                     // Ensure at least one property exists for each node

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -831,7 +831,7 @@ public class DwsimModelParser
             bool isReadOnly = writeProperties is null || !((IList)writeProperties).Contains(propertyKey);
 
             // Apply API length limit to property name
-            string safeName = EnsureMaxLength(GetHumanReadablePropertyName(propertyKey), _modelParsingConfig.MaxPropertyNameLength);
+            string safeName = EnsureMaxLength(GetHumanReadablePropertyName(propertyKey) ?? propertyKey, _modelParsingConfig.MaxPropertyNameLength);
 
             return new SimulatorModelRevisionDataProperty
             {

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -337,11 +337,7 @@ public class DwsimModelParser
                 }
             }
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, "Failed to parse nodes with properties");
         }

--- a/Connector/Dwsim/DwsimModelParser.cs
+++ b/Connector/Dwsim/DwsimModelParser.cs
@@ -149,12 +149,7 @@ public class DwsimModelParser
             _logger.LogDebug("DWSIM model parsing completed successfully");
             return flowsheet;
         }
-        catch (OperationCanceledException)
-        {
-            _logger.LogInformation("Model parsing was cancelled");
-            throw;
-        }
-        catch (Exception e)
+        catch (Exception e) when (e is not OperationCanceledException)
         {
             _logger.LogError(e, "Error while parsing DWSIM model: {EMessage}", e.Message);
             return null;


### PR DESCRIPTION
This PR is the final PR in a series to implement model revision parsing with flowsheet extraction for DWSIM. In this PR we:
- Integrate the DWSIM model parser into the connector workflow, enabling extraction of flowsheet nodes, edges, thermodynamic data, and unit operations properties
- Handle API constraints with configurable limits (allows for simple update if the API relax some constraints in the future)
- Fix COM object property extraction by using the correct DWSIM API method